### PR TITLE
Fix permissions for files in install/

### DIFF
--- a/support/docker/Dockerfile
+++ b/support/docker/Dockerfile
@@ -14,6 +14,11 @@ ENV BPMS_VERSION_BUILD redhat-1
 # ADD Installation Files
 COPY support/installation-bpms support/installation-bpms.variables installs/jboss-bpms-installer-$BPMS_VERSION_MAJOR.$BPMS_VERSION_MINOR.$BPMS_VERSION_MICRO.GA-$BPMS_VERSION_BUILD.jar  /opt/jboss/
 
+# Make sure permissions are correct
+USER root
+RUN chmod -R a+r /opt/jboss
+USER jboss 
+
 # Configure project prerequisites and run installer and cleanup installation components
 RUN mkdir -p /opt/jboss/bpms-projects \
   && sed -i "s:<installpath>.*</installpath>:<installpath>$BPMS_HOME</installpath>:" /opt/jboss/installation-bpms \


### PR DESCRIPTION
If install/jboss-bpms-installer-6.0.3.GA-redhat-1.jar has "wrong" permissions, e.g.  640 (-rw-r-----) docker build will fail because the jar cannot be accessed:
Step 8 : RUN ls -l /opt/jboss/ && mkdir -p /opt/jboss/bpms-projects   && sed -i "s:<installpath>.*</installpath>:<installpath>$BPMS_HOME</installpath>:" /opt/jboss/installation-bpms   && java -jar /opt/jboss/jboss-bpms-installer-$BPMS_VERSION_MAJOR.$BPMS_VERSION_MINOR.$BPMS_VERSION_MICRO.GA-$BPMS_VERSION_BUILD.jar  /opt/jboss/installation-bpms -variablefile /opt/jboss/installation-bpms.variables   && rm -rf /opt/jboss/jboss-bpms-installer-$BPMS_VERSION_MAJOR.$BPMS_VERSION_MINOR.$BPMS_VERSION_MICRO.GA-$BPMS_VERSION_BUILD.jar /opt/jboss/installation-bpms /opt/jboss/installation-bpms.variables $BPMS_HOME/jboss-eap-6.1/standalone/configuration/standalone_xml_history/
 ---> Running in cde13aa14923
total 300840
-rw-r--r-- 1 root root      2487 Feb 27 15:52 installation-bpms
-rw-r--r-- 1 root root       175 Feb 27 15:52 installation-bpms.variables
-rw-r----- 1 root root 308049404 Mar  4 15:46 jboss-bpms-installer-6.0.3.GA-redhat-1.jar
Error: Unable to access jarfile /opt/jboss/jboss-bpms-installer-6.0.3.GA-redhat-1.jar

So make sure to fix the permissions.
